### PR TITLE
Add info on uncaught exceptions

### DIFF
--- a/src/ToolChain/ToolChain.cpp
+++ b/src/ToolChain/ToolChain.cpp
@@ -223,6 +223,10 @@ int ToolChain::Initialise(){
 	
       }
       
+      catch(std::exception& e){
+	logmessage<<e.what()<<std::endl;
+	throw;
+      }
       catch(...){
 	//*(m_data.Log)<<"WARNING !!!!! "<<m_toolnames.at(i)<<" Failed to initialise (uncaught error)"<<std::endl<<std::endl;
 	logmessage<<"WARNING !!!!! "<<m_toolnames.at(i)<<" Failed to initialise (uncaught error)"<<std::endl;
@@ -320,6 +324,10 @@ int ToolChain::Execute(int repeates){
 	  }  
 	}
 	
+	catch(std::exception& e){
+	  logmessage<<e.what()<<std::endl;
+	  throw;
+	}
 	catch(...){
 	  // *(m_data.Log)<<"WARNING !!!!!! "<<m_toolnames.at(i)<<" Failed to execute (uncaught error)"<<std::endl<<std::endl;
 	  logmessage<<"WARNING !!!!!! "<<m_toolnames.at(i)<<" Failed t\
@@ -416,6 +424,10 @@ int ToolChain::Finalise(){
 	}  
       }
       
+      catch(std::exception& e){
+	logmessage<<e.what()<<std::endl;
+	throw;
+      }
       catch(...){
 	//*(m_data.Log)<<"WARNING !!!!!!! "<<m_toolnames.at(i)<<" Finalised successfully (uncaught error)"<<std::endl<<std::endl;
 	logmessage<<"WARNING !!!!!!! "<<m_toolnames.at(i)<<" Finalised successfully (uncaught error)"<<std::endl;


### PR DESCRIPTION
before each `catch(...)` it now catches anything deriving from std::exception and adds the exception message to the printout. it then rethrows so that subsequent behaviour is the same. Since logmessage isn't cleared before being printed, the information gets carried over and prepended to the standard print message.